### PR TITLE
Add infinite scroll in folders.

### DIFF
--- a/www-src/app/collections/files.coffee
+++ b/www-src/app/collections/files.coffee
@@ -1,5 +1,7 @@
 File = require '../models/file'
 
+PAGE_LENGTH = 20
+
 module.exports = class FileAndFolderCollection extends Backbone.Collection
     model: File
 
@@ -26,43 +28,72 @@ module.exports = class FileAndFolderCollection extends Backbone.Collection
                 callback err
 
     # fetch use
-    fetch: (_callback = ->) ->
-        callback = (err) =>
+    fetch: (callback = ->) ->
+
+
+        @reset []
+        @offset = 0
+        # Speed optimisation :
+        # First, fetch ordered files ids: all at once;
+        # Then, load docs on demand.
+        @_fetchPathes @path, (err, results) =>
+            @inPathIds = results.rows.map (row) -> return row.id
+            @trigger 'fullsync'
+            @loadNextPage callback
+
+
+    loadNextPage: (_callback) ->
+        callback = (err, noMoreItems) =>
             @notloaded = false
             @trigger 'sync'
-            _callback(err)
+            _callback(err, noMoreItems)
 
-        @_fetch @path, (err, items) =>
+        @_fetchNextPageDocs (err, items) =>
             return callback err if err
-            @trigger 'fullsync'
-            @slowReset items, (err) =>
-                callback err
+            @offset += PAGE_LENGTH
 
+            models = @_rowsToModels items
+            noMoreItems = models.length < PAGE_LENGTH
 
-    _fetch: (path, callback) ->
+            @add models
+            callback err, noMoreItems
+
+    # Fetch all key and id for the specified path
+    _fetchPathes: (path, callback) ->
         if path is t 'photos'
             params =
                 endkey: if path then ['/' + path] else ['']
                 startkey: if path then ['/' + path, {}] else ['', {}]
-                include_docs: true
                 descending: true
             view = 'Pictures'
         else
             params =
                 startkey: if path then ['/' + path] else ['']
                 endkey: if path then ['/' + path, {}] else ['', {}]
-                include_docs: true
             view = 'FilesAndFolder'
 
         app.replicator.db.query view, params, callback
 
-    slowReset: (results, callback) ->
-        models = results.rows.map (row) ->
+    # Fetch the docs for the next files.
+    _fetchNextPageDocs: (callback) ->
+        ids = @inPathIds.slice @offset, @offset + PAGE_LENGTH
+
+        params =
+            keys: ids
+            include_docs: true
+
+        app.replicator.db.allDocs params, callback
+
+    _rowsToModels: (results) ->
+        return results.rows.map (row) ->
             doc = row.doc
             if binary_id = doc.binary?.file?.id
                 doc.incache = app.replicator.fileInFileSystem doc
                 doc.version = app.replicator.fileVersion doc
             return doc
+
+    slowReset: (results, callback) ->
+        models = @_rowsToModels results
 
         #immediately reset 10 models (fill view)
         @reset models.slice 0, 10

--- a/www-src/app/styles/application.styl
+++ b/www-src/app/styles/application.styl
@@ -153,13 +153,7 @@ img.backup
         display none
 
 
-    #shadow
-        position absolute
-        width 10px
-        height 30px
-        right 0px
-        top 0px
-        background linear-gradient(left, rgba(0,0,0,0), white);
+    
 
     ul
         margin-bottom 0px
@@ -273,3 +267,19 @@ img.backup
         border-top-right-radius 10px
         border-bottom-right-radius 10px
         background basecolor
+
+#shadow
+    position absolute
+    width 10px
+    height 30px
+    right 0px
+    top 0px
+    background linear-gradient(left, rgba(255,255,255,0), white);
+
+#headerSpinner
+    position absolute
+    right 0px
+    padding 4px
+    background-color white
+    height 32px
+    

--- a/www-src/app/templates/layout.jade
+++ b/www-src/app/templates/layout.jade
@@ -6,7 +6,10 @@
     h1#title.title Loading
     #breadcrumbs
 
-    a#headerSpinner.button.button-icon: img(src="img/spinner.svg", width="25")
+    a#headerSpinner.button.button-icon
+      #shadow(style="right: 30px;")
+      img(src="img/spinner.svg", width="25")
+
   .bar.bar-subheader.bar-calm
     h2#backupIndicator.title
 

--- a/www-src/app/views/folder.coffee
+++ b/www-src/app/views/folder.coffee
@@ -64,6 +64,8 @@ module.exports = class FolderView extends CollectionView
                     e.stopPropagation()
 
     onChange: =>
+        app.layout.ionicScroll.resize()
+
         @$('#empty-message').remove()
         if _.size(@views) is 0
             message = if @collection.notloaded then 'loading'
@@ -73,6 +75,11 @@ module.exports = class FolderView extends CollectionView
             $('<li class="item" id="empty-message">')
             .text(t(message))
             .appendTo @$el
+
+        else unless @collection.allPagesLoaded
+            $('<li class="item" id="empty-message">')
+                .text(t('loading'))
+                .appendTo @$el
 
     appendView: (view) =>
         super
@@ -109,11 +116,11 @@ module.exports = class FolderView extends CollectionView
             @loadMore()
 
     loadMore: (callback) ->
-        if not @collection.notLoaded and not @isLoading and not @lastAlreadyLoaded
+        if not @collection.notLoaded and
+           not @isLoading and
+           not @collection.allPagesLoaded
             @isLoading = true
-            @collection.loadNextPage (err, noMoreEvents) =>
-                if noMoreEvents
-                    @lastAlreadyLoaded = true
+            @collection.loadNextPage (err) =>
 
                 @isLoading = false
                 callback?()


### PR DESCRIPTION
- Dirty fix on drags, to avoid floating feeling with the menu while scrolling.
- Fix breadcrumbs moving when sync loader appears and disappears.

- Quick and naive implementation of infinite scroll in folders :
    - speed optimisation with pouchDB : load docs id (and order only once), fetch docs by pages.
    - allows to view and scroll a big photo folders
    But actually :
    - no recycling : on _cozy-phone_ UI is usable up to 500 files, then it lags a lot.

label : in progress