### PR TITLE
Automatically update files in cache

### DIFF
--- a/www-src/app/collections/files.coffee
+++ b/www-src/app/collections/files.coffee
@@ -89,9 +89,15 @@ module.exports = class FileAndFolderCollection extends Backbone.Collection
     _rowsToModels: (results) ->
         return results.rows.map (row) ->
             doc = row.doc
-            if binary_id = doc.binary?.file?.id
-                doc.incache = app.replicator.fileInFileSystem doc
-                doc.version = app.replicator.fileVersion doc
+            if doc.docType.toLowerCase() is 'file'
+                if binary_id = doc.binary?.file?.id
+                    doc.incache = app.replicator.fileInFileSystem doc
+                    doc.version = app.replicator.fileVersion doc
+
+            else if doc.docType.toLowerCase() is 'folder'
+                # TODO ASYNC !  doc.incache = app.replicator.folderInFileSystem doc
+                doc.incache = false
+
             return doc
 
     slowReset: (results, callback) ->

--- a/www-src/app/replicator/filesystem.coffee
+++ b/www-src/app/replicator/filesystem.coffee
@@ -42,6 +42,12 @@ module.exports.getFile = (parent, name, callback) ->
     onError = (err) -> callback err
     parent.getFile name, null, onSuccess, onError
 
+module.exports.moveTo = (entry, directory, name, callback) ->
+    onSuccess = (entry) -> callback null, entry
+    onError = (err) -> callback err
+    entry.moveTo directory, name, null, onSuccess, onError
+
+
 module.exports.getDirectory = (parent, name, callback) ->
     onSuccess = (entry) -> callback null, entry
     onError = (err) -> callback err
@@ -101,6 +107,7 @@ module.exports.metadataFromEntry = (entry, callback) ->
     onSuccess = (file) -> callback null, file
     onError = (err) -> callback err
     entry.getMetadata onSuccess, onError
+
 
 
 module.exports.download = (options, progressback, callback) ->

--- a/www-src/app/replicator/main.coffee
+++ b/www-src/app/replicator/main.coffee
@@ -50,17 +50,20 @@ module.exports = class Replicator extends Backbone.Model
                 @config = new ReplicatorConfig(this)
                 @config.fetch callback
 
+    # Find all files in (recursively) the specified folder.
     getDbFilesOfFolder: (folder, callback) ->
         path = folder.path
+        path += '/' + folder.name
         options =
-            startkey: if path then ['/' + path] else ['']
-            endkey: if path then ['/' + path, {}] else ['', {}]
+            startkey: [path]
+            endkey: [path + '/\uffff', {}]
             include_docs: true
 
         @db.query 'FilesAndFolder', options, (err, results) ->
             return callback err if err
             docs = results.rows.map (row) -> row.doc
             files = docs.filter (doc) -> doc.docType?.toLowerCase() is 'file'
+
             callback null, files
 
     registerRemote: (config, callback) ->

--- a/www-src/app/replicator/main.coffee
+++ b/www-src/app/replicator/main.coffee
@@ -2,6 +2,7 @@ request = require '../lib/request'
 fs = require './filesystem'
 makeDesignDocs = require './replicator_mapreduce'
 ReplicatorConfig = require './replicator_config'
+DeviceStatus = require '../lib/device_status'
 DBNAME = "cozy-files.db"
 DBCONTACTS = "cozy-contacts.db"
 DBPHOTOS = "cozy-photos.db"
@@ -296,25 +297,24 @@ module.exports = class Replicator extends Backbone.Model
                                 @cache.splice index, 1
                                 break
 
-
+    # Update the local copy  (options.entry) of the file (options.file)
     updateLocal: (options, callback) =>
         file = options.file
         entry = options.entry
-        # check binary revs # actually can't test, no way to change a file in cozy ?
-        if entry.name isnt file.binary.file.id + '-' + file.binary.file.rev
+
+        if file._deleted
+            @removeLocal file, callback
+
+        # check binary revs
+        else if entry.name isnt file.binary.file.id + '-' + file.binary.file.rev
             # Don't update the binary if "no wifi"
             DeviceStatus.checkReadyForSync (err, ready, msg) =>
                 if ready
-                    # remove old one.
-                    fs.rmrf entry, (err) =>
-                        return callback err if err
-                        # remove from @cache
-                        for entry, index in @cache when entry.name is binary_id + '-' + binary_rev
-                            @cache.splice index, 1
-                            break
-
-                        # Download the new version.
-                        @getBinary file, callback
+                    # Download the new version.
+                    noop = ->
+                    @getBinary file, noop, callback
+                else
+                    callback()
 
         else # check filename
             fs.getChildren entry, (err, children) =>
@@ -372,6 +372,21 @@ module.exports = class Replicator extends Backbone.Model
 
         return fileNEntriesInCache
 
+    _replicationFilter: ->
+        if @config.get 'cozyNotifications'
+            filter = (doc) ->
+                return doc.docType?.toLowerCase() is 'folder' or
+                    doc.docType?.toLowerCase() is 'file' or
+                    doc.docType?.toLowerCase() is 'notification' and
+                        doc.type?.toLowerCase() is 'temporary'
+
+        else
+            filter = (doc) ->
+                return doc.docType?.toLowerCase() is 'folder' or
+                    doc.docType?.toLowerCase() is 'file'
+
+        return filter
+
     # wrapper around _sync to maintain the state of inSync
     sync: (options, callback) ->
         return callback null if @get 'inSync'
@@ -390,30 +405,19 @@ module.exports = class Replicator extends Backbone.Model
         console.log "BEGIN SYNC"
         total_count = 0
         @liveReplication?.cancel()
+        changedDocs = []
         checkpoint = options.checkpoint or @config.get 'checkpointed'
-
-        if options.notificationsOnly
-            filter = (doc) ->
-                return doc.docType?.toLowerCase() is 'notification' and
-                    doc.type?.toLowerCase() is 'temporary'
-        else
-            filter = (doc) ->
-                return doc.docType?.toLowerCase() is 'folder' or
-                    doc.docType?.toLowerCase() is 'file' or
-                    doc.docType?.toLowerCase() is 'notification' and
-                        doc.type?.toLowerCase() is 'temporary'
 
         replication = @db.replicate.from @config.remote,
             batch_size: 20
             batches_limit: 5
-            filter: filter
+            filter: @_replicationFilter()
             live: false
             since: checkpoint
 
         replication.on 'change', (change) =>
-            fileNEntriesInCache = @_filesNEntriesInCache change.docs
-            async.eachSeries fileNEntriesInCache, @updateLocal, =>
-                console.log "done update files !"
+            console.log "REPLICATION CHANGE"
+            changedDocs = changedDocs.concat change.docs
 
         replication.once 'error', (err) =>
             console.log "REPLICATOR ERROR #{JSON.stringify(err)} #{err.stack}"
@@ -425,14 +429,16 @@ module.exports = class Replicator extends Backbone.Model
 
         replication.once 'complete', (result) =>
             console.log "REPLICATION COMPLETED"
-            @config.save checkpointed: result.last_seq, (err) =>
-                callback err
-                unless options.background
-                    app.router.forceRefresh()
-                    # updateIndex In background
-                    @updateIndex =>
-                        console.log 'start Realtime'
-                        @startRealtime()
+            async.eachSeries @_fileNEntriesInCache(changedDocs), \
+                @updateLocal, (err) =>
+                @config.save checkpointed: result.last_seq, (err) =>
+                    callback err
+                    unless options.background
+                        app.router.forceRefresh()
+                        # updateIndex In background
+                        @updateIndex =>
+                            console.log 'start Realtime'
+                            @startRealtime()
 
     # realtime
     # start from the last checkpointed value
@@ -441,17 +447,15 @@ module.exports = class Replicator extends Backbone.Model
     # with exponential backoff 2^x s (max 1min)
     #
     realtimeBackupCoef = 1
+
     startRealtime: =>
         return if @liveReplication
         console.log 'REALTIME START'
+
         @liveReplication = @db.replicate.from @config.remote,
             batch_size: 20
             batches_limit: 5
-            filter: (doc) ->
-                return doc.docType?.toLowerCase() is 'folder' or
-                    doc.docType?.toLowerCase() is 'file' or
-                    doc.docType?.toLowerCase() is 'notification' and
-                        doc.type?.toLowerCase() is 'temporary'
+            filter: @_replicationFilter()
             since: @config.get 'checkpointed'
             continuous: true
 
@@ -488,8 +492,7 @@ module.exports = class Replicator extends Backbone.Model
 
     # Update cache files with outdated revisions.
     syncCache:  (callback) =>
-        # No optim yet !
-        # To test, with binary version changes !
+        # TODO: Add optimizations on db.query : avoid include_docs on big list.
         options =
             keys: @cache.map (entry) -> return entry.name.split('-')[0]
             include_docs: true
@@ -497,6 +500,4 @@ module.exports = class Replicator extends Backbone.Model
         @db.query 'ByBinaryId', options, (err, results) =>
             return callback err if err
             toUpdate = @_filesNEntriesInCache results.rows.map (row) -> row.doc
-
-            console.log toUpdate
             async.eachSeries toUpdate, @updateLocal, callback

--- a/www-src/app/replicator/replicator_backups.coffee
+++ b/www-src/app/replicator/replicator_backups.coffee
@@ -39,9 +39,14 @@ module.exports =
             console.log "WE ARE READY FOR SYNC"
 
             @syncPictures force, (err) =>
+                console.log "done syncPict"
                 return callback err if err
-                @syncContacts (err) =>
-                    callback err
+                @syncCache (err) =>
+                    console.log "done syncCache"
+
+                    return callback err if err
+                    @syncContacts (err) =>
+                        callback err
 
 
     syncContacts: (callback) ->

--- a/www-src/app/replicator/replicator_mapreduce.coffee
+++ b/www-src/app/replicator/replicator_mapreduce.coffee
@@ -29,6 +29,15 @@ FilesAndFolderDesignDoc =
                     if doc.docType?.toLowerCase() is 'folder'
                         emit [doc.path, '1_' + doc.name.toLowerCase()]
 
+ByBinaryIdDesignDoc =
+    _id: '_design/ByBinaryId'
+    version: 1
+    views:
+        'ByBinaryId':
+            map: Object.toString.apply (doc) ->
+                if doc.docType?.toLowerCase() is 'file'
+                    emit doc.binary?.file?.id
+
 PicturesDesignDoc =
     _id: '_design/Pictures'
     version: 1
@@ -88,6 +97,7 @@ module.exports = (db, contactsDB, photosDB, callback) ->
     async.series [
         (cb) -> createOrUpdateDesign db, NotificationsTemporaryDesignDoc, cb
         (cb) -> createOrUpdateDesign db, FilesAndFolderDesignDoc, cb
+        (cb) -> createOrUpdateDesign db, ByBinaryIdDesignDoc, cb
         (cb) -> createOrUpdateDesign db, PicturesDesignDoc, cb
         (cb) -> createOrUpdateDesign db, LocalPathDesignDoc, cb
         (cb) -> createOrUpdateDesign db, PathToBinaryDesignDoc, cb

--- a/www-src/app/service/service.coffee
+++ b/www-src/app/service/service.coffee
@@ -48,26 +48,12 @@ module.exports = Service =
                         # give some time to finish and close things.
                         setTimeout window.service.workDone, 5 * 1000
 
-                    syncNotifications = (err) ->
-                        if config.get 'cozyNotifications'
-                            app.replicator.sync
-                                background: true
-                                notificationsOnly: true
-                            , delayedQuit
-
-                        else
-                            delayedQuit()
-
                     if config.get 'syncImages'
                         app.replicator.backup { background: true }, (err) ->
-                            if err and err.message is 'no wifi'
-                                syncNotifications()
-
-                            else
-                                app.replicator.sync {background: true}, delayedQuit
+                            app.replicator.sync {background: true}, delayedQuit
 
                     else
-                        syncNotifications()
+                        app.replicator.sync {background: true}, delayedQuit
 
 
                 else

--- a/www-src/app/service/service_manager.coffee
+++ b/www-src/app/service/service_manager.coffee
@@ -9,11 +9,10 @@ module.exports = class ServiceManager extends Backbone.Model
     initialize: ->
         config = app.replicator.config
         # Initialize plugin with current config values.
-        @toggle config, config.get 'cozyNotifications'
         @listenNewPictures config, config.get 'syncImages'
+        @toggle config, true
 
         # Listen to updates.
-        @listenTo app.replicator.config, "change:cozyNotifications", @toggle
         @listenTo app.replicator.config, "change:syncImages", @listenNewPictures
 
         @checkActivated()

--- a/www-src/app/templates/folder_line.jade
+++ b/www-src/app/templates/folder_line.jade
@@ -9,7 +9,7 @@
     span= model.name
 
     if isFolder
-        i.icon.ion-chevron-right
+        i.cache-indicator.icon.ion-ios7-cloud-download-outline
     else if model.incache && model.version
         i.cache-indicator.icon.ion-iphone
     else if model.incache

--- a/www-src/app/views/menu.coffee
+++ b/www-src/app/views/menu.coffee
@@ -29,17 +29,18 @@ module.exports = class Menu extends BaseView
     backup: ->
         app.layout.closeMenu()
 
-        if app.replicator.get 'inBackup'
-            @sync()
-        else
-            app.replicator.backup { force: false }, (err) =>
-                if err
-                    console.log err, err.stack
-                    alert t err.message
-                    return
+        @sync()
+        # if app.replicator.get 'inBackup'
+        #     @sync()
+        # else
+        #     app.replicator.backup { force: false }, (err) =>
+        #         if err
+        #             console.log err, err.stack
+        #             alert t err.message
+        #             return
 
-                app.layout.currentView?.collection?.fetch()
-                @sync()
+        #         app.layout.currentView?.collection?.fetch()
+        #         @sync()
 
     doSearchIfEnter: (event) => @doSearch() if event.which is 13
     doSearch: ->

--- a/www-src/app/views/menu.coffee
+++ b/www-src/app/views/menu.coffee
@@ -29,18 +29,17 @@ module.exports = class Menu extends BaseView
     backup: ->
         app.layout.closeMenu()
 
-        @sync()
-        # if app.replicator.get 'inBackup'
-        #     @sync()
-        # else
-        #     app.replicator.backup { force: false }, (err) =>
-        #         if err
-        #             console.log err, err.stack
-        #             alert t err.message
-        #             return
+        if app.replicator.get 'inBackup'
+            @sync()
+        else
+            app.replicator.backup { force: false }, (err) =>
+                if err
+                    console.log err, err.stack
+                    alert t err.message
+                    return
 
-        #         app.layout.currentView?.collection?.fetch()
-        #         @sync()
+                app.layout.currentView?.collection?.fetch()
+                @sync()
 
     doSearchIfEnter: (event) => @doSearch() if event.which is 13
     doSearch: ->


### PR DESCRIPTION
* update binary in cache
* update filename in cache
* remove binary in cache if file is removed
* add a whole directory in cache.
* change behavior of settings against service lifecycle : service always started (each 15'), even if notifications is unchecked.

May discuss before merge :
* add a settings to avoid service (for autonomy freaks)
* add true folder cache (automatically add new files of the folder to cache)