### PR TITLE
Some fixes around data consumption.

### DIFF
--- a/www-src/app/application.coffee
+++ b/www-src/app/application.coffee
@@ -53,6 +53,11 @@ module.exports =
                             else
                                 app.replicator.backup()
                         , false
+                        document.addEventListener "pause", =>
+                            console.log "PAUSE EVENT"
+                            app.replicator.stopRealtime()
+
+                        , false
                         document.addEventListener 'offline', ->
                             device_status = require './lib/device_status'
                             device_status.update()

--- a/www-src/app/application.coffee
+++ b/www-src/app/application.coffee
@@ -43,36 +43,43 @@ module.exports =
                 Backbone.history.start()
 
                 if config.remote
-                    @router.navigate 'folder/', trigger: true
-                    @router.once 'collectionfetched', =>
-                        app.replicator.startRealtime()
+                    app.regularStart()
 
-                        app.replicator.backup()
-                        document.addEventListener "resume", =>
-                            console.log "RESUME EVENT"
-                            if app.backFromOpen
-                                app.backFromOpen = false
-                                app.replicator.startRealtime()
-                            else
-                                app.replicator.backup()
-                        , false
-                        document.addEventListener "pause", =>
-                            console.log "PAUSE EVENT"
-                            app.replicator.stopRealtime()
-
-                        , false
-                        document.addEventListener 'offline', ->
-                            device_status = require './lib/device_status'
-                            device_status.update()
-                        , false
-                        document.addEventListener 'online', ->
-                            device_status = require './lib/device_status'
-                            device_status.update()
-                            backup = () ->
-                                app.replicator.backup(true)
-                                window.removeEventListener 'realtime:onChange', backup, false
-                            window.addEventListener 'realtime:onChange', backup, false
-                        , false
                 else
+                    # App's first start
                     @router.navigate 'login', trigger: true
 
+    regularStart: ->
+        app.foreground = true
+
+        document.addEventListener "resume", =>
+            console.log "RESUME EVENT"
+            app.foreground = true
+            if app.backFromOpen
+                app.backFromOpen = false
+                app.replicator.startRealtime()
+            else
+                app.replicator.backup()
+        , false
+        document.addEventListener "pause", =>
+            console.log "PAUSE EVENT"
+            app.foreground = false
+            app.replicator.stopRealtime()
+
+        , false
+        document.addEventListener 'offline', ->
+            device_status = require './lib/device_status'
+            device_status.update()
+        , false
+        document.addEventListener 'online', ->
+            device_status = require './lib/device_status'
+            device_status.update()
+            backup = () ->
+                app.replicator.backup(true)
+                window.removeEventListener 'realtime:onChange', backup, false
+            window.addEventListener 'realtime:onChange', backup, false
+        , false
+
+        @router.navigate 'folder/', trigger: true
+        @router.once 'collectionfetched', =>
+            app.replicator.backup()

--- a/www-src/app/application.coffee
+++ b/www-src/app/application.coffee
@@ -1,6 +1,7 @@
 Replicator = require './replicator/main'
 LayoutView = require './views/layout'
 ServiceManager = require './service/service_manager'
+Notifications = require '../views/notifications'
 
 module.exports =
 
@@ -35,6 +36,7 @@ module.exports =
                     console.log err, err.stack
                     return alert err.message or err
 
+                @notificationManager = new Notifications()
                 @serviceManager = new ServiceManager()
 
                 $('body').empty().append @layout.render().$el
@@ -50,6 +52,7 @@ module.exports =
                             console.log "RESUME EVENT"
                             if app.backFromOpen
                                 app.backFromOpen = false
+                                app.replicator.startRealtime()
                             else
                                 app.replicator.backup()
                         , false

--- a/www-src/app/locales/en.coffee
+++ b/www-src/app/locales/en.coffee
@@ -102,3 +102,4 @@ module.exports =
     "photo folder not replicated yet" : "Initialization not finished yet."
     "Not Found" : "Error while initializing. Did you install the Files application in your Cozy ?"
     "connexion error": "We failed to connect to your cozy. Please check that your device is connected to the internet, the address of your cozy is spelled correctly and your cozy is running. If you are an advanced user with a self hosted cozy, refer to the <a href='http://cozy.io/en/mobile/files.html#note-about-self-signed-certificates' target='_system'>doc to handle self-signed certificates</a>."
+    "no images in DCIM": "Backup images : no image found in DCIM dir."

--- a/www-src/app/locales/fr.coffee
+++ b/www-src/app/locales/fr.coffee
@@ -102,3 +102,4 @@ module.exports =
     "photo folder not replicated yet" : "L'initialisation n'est pas terminée."
     "Not Found" : "Erreur à l'initialisation. Avez-vous installé l'application Files sur votre Cozy ?"
     "connexion error": "La connection à votre cozy a échoué. Vérifiez que votre terminal est connecté à internet, que l'adresse de votre cozy est bien écrite et que votre cozy fonctionne. Pour les utilisateurs avancés avec un cozy auto-hébergé, consulter la <a href='http://cozy.io/fr/mobile/files.html#a-propos-des-certificats-auto-sign-s' target='_system'>documentation à propos des certificats autosignés</a>"
+    "no images in DCIM": "Sauvegarde des images : aucune image trouvée dans le répertoire DCIM."

--- a/www-src/app/replicator/main.coffee
+++ b/www-src/app/replicator/main.coffee
@@ -452,7 +452,9 @@ module.exports = class Replicator extends Backbone.Model
     realtimeBackupCoef = 1
 
     startRealtime: =>
-        return if @liveReplication
+        if @liveReplication or not app.foreground
+            return
+
         console.log 'REALTIME START'
 
         @liveReplication = @db.replicate.from @config.remote,

--- a/www-src/app/replicator/main.coffee
+++ b/www-src/app/replicator/main.coffee
@@ -484,7 +484,6 @@ module.exports = class Replicator extends Backbone.Model
             console.log "LIVE REPLICATION CANCELLED"
             @set 'inSync', false
             @liveReplication = null
-            #@startRealtime() #WTF !!?
 
         @liveReplication.once 'error', (e) =>
             @liveReplication = null

--- a/www-src/app/replicator/replicator_backups.coffee
+++ b/www-src/app/replicator/replicator_backups.coffee
@@ -160,6 +160,10 @@ module.exports =
 
             toUpload = []
 
+            # Filter images : keep only the ones from Camera
+            # TODO: Android Specific !
+            images = images.filter (path) -> path.indexOf('/DCIM/') != -1
+
             # step 1 scan all images, find the new ones
             async.eachSeries images, (path, cb) =>
                 #Check if pictures is in dbImages

--- a/www-src/app/replicator/replicator_backups.coffee
+++ b/www-src/app/replicator/replicator_backups.coffee
@@ -164,6 +164,9 @@ module.exports =
             # TODO: Android Specific !
             images = images.filter (path) -> path.indexOf('/DCIM/') != -1
 
+            if images.length is 0
+                callback new Error 'no images in DCIM'
+
             # step 1 scan all images, find the new ones
             async.eachSeries images, (path, cb) =>
                 #Check if pictures is in dbImages

--- a/www-src/app/replicator/replicator_backups.coffee
+++ b/www-src/app/replicator/replicator_backups.coffee
@@ -21,7 +21,7 @@ module.exports =
 
         @set 'inBackup', true
         @set 'backup_step', null
-        @liveReplication?.cancel()
+        @stopRealtime()
         @_backup options.force, (err) =>
             @set 'backup_step', null
             @set 'inBackup', false

--- a/www-src/app/service/service.coffee
+++ b/www-src/app/service/service.coffee
@@ -10,9 +10,6 @@ Notifications = require '../views/notifications'
 module.exports = Service =
 
     initialize: ->
-        # "Watchdog" : in all cases, kill service after 10'
-        setTimeout window.service.workDone, 10 * 60 * 1000
-
         window.app = this
 
         # Monkey patch for browser debugging
@@ -46,7 +43,11 @@ module.exports = Service =
                     delayedQuit = (err) ->
                         console.log err if err
                         # give some time to finish and close things.
-                        setTimeout window.service.workDone, 5 * 1000
+                        setTimeout ->
+                            # call this javabinding directly on object to avoid
+                            # Error 'NPMethod called on non-NPObject'
+                            window.service.workDone()
+                        , 5 * 1000
 
                     syncNotifications = (err) ->
                         if config.get 'cozyNotifications'
@@ -70,5 +71,20 @@ module.exports = Service =
                 else
                     window.service.workDone()
 
+
+
 document.addEventListener 'deviceready', ->
-    Service.initialize()
+    try
+        Service.initialize()
+
+    catch error
+        console.log 'EXCEPTION SERVICE INITIALIZATION !'
+        console.log error
+
+    finally
+        # "Watchdog" : in all cases, kill service after 10'
+        setTimeout ->
+            # call this javabinding directly on object to avoid
+            # Error 'NPMethod called on non-NPObject'
+            window.service.workDone()
+        , 10 * 60 * 1000

--- a/www-src/app/service/service.coffee
+++ b/www-src/app/service/service.coffee
@@ -48,17 +48,27 @@ module.exports = Service =
                         # give some time to finish and close things.
                         setTimeout window.service.workDone, 5 * 1000
 
+                    syncNotifications = (err) ->
+                        if config.get 'cozyNotifications'
+                            app.replicator.sync
+                                background: true
+                                notificationsOnly: true
+                            , delayedQuit
+                        else
+                            delayedQuit()
+
                     if config.get 'syncImages'
                         app.replicator.backup { background: true }, (err) ->
-                            app.replicator.sync {background: true}, delayedQuit
+                            if err and err.message is 'no wifi'
+                                syncNotifications()
+                            else
+                                app.replicator.sync {background: true}, delayedQuit
 
                     else
-                        app.replicator.sync {background: true}, delayedQuit
-
+                        syncNotifications()
 
                 else
                     window.service.workDone()
-
 
 document.addEventListener 'deviceready', ->
     Service.initialize()

--- a/www-src/app/service/service_manager.coffee
+++ b/www-src/app/service/service_manager.coffee
@@ -1,3 +1,22 @@
+# Service lifecycle
+#
+# Service is started on :
+#   Repeatedly
+#
+#   if syncImage
+#       New Picture Intent
+#       New connection on Wifi
+#
+# Service do
+#   if Wifi
+#       Backup images (if syncImages)
+#       Sync
+#       Update cache
+#
+#   if cozyNotifications
+#       Sync notifications
+#       Display notifications
+#
 
 repeatingPeriod = 15 * 60 * 1000
 

--- a/www-src/app/views/first_sync.coffee
+++ b/www-src/app/views/first_sync.coffee
@@ -34,11 +34,6 @@ module.exports = class FirstSyncView extends BaseView
         console.log "end #{step}"
         return if step isnt 3
 
-        # start the first contact & pictures backup
-        app.replicator.backup (err) ->
-            alert err if err
-            console.log "pics & contacts synced"
-
-        # go to home
         app.isFirstRun = false
-        app.router.navigate 'folder/', trigger: true
+
+        app.regularStart()


### PR DESCRIPTION
- Fix continuous replication note stopped while app in background. 
- If no wifi, only notification (if activated) are synchronized. 
- Fix regression with cache update : service never stop.

- Add filter on synced picture : keep only images from camera.

since b74e6b0 :
- Fix continuous replication started while app in background
- Fix pause and resume callback not initialized on first start (which may implies continuous replication in background)

Those patches (and somes in previous PR around service life-cycle) may fix fair-use bug : 
pouchdb doesn't like to run twice as the same time : two browsers running pouchdb on the same sqlite backend (same data). When it occurs, pouchdb may become floody for ~5minutes, ~2000request, 5Mo.
There is mutex mechanisms in service and app to avoid this situation, but they rely on week signals (onPause / onResume) and not on the true use of the sqlite db. So, the problem may come back, and fair use bug may have another source !
