### PR TITLE
Move to simpler brute force substring search

### DIFF
--- a/www-src/app/collections/files.coffee
+++ b/www-src/app/collections/files.coffee
@@ -18,21 +18,20 @@ module.exports = class FileAndFolderCollection extends Backbone.Collection
         @query = options.query
         @notloaded = true
 
+
     isSearch: -> @path is undefined
 
-    # search use temporary view
-    search: (callback) ->
-        params =
-            query: @query
-            fields: ['name']
-            include_docs: true
 
-        app.replicator.db.search params, (err, items) =>
-            @slowReset items, (err) =>
-                @notloaded = false
-                @allPagesLoaded = true
-                @trigger 'sync'
-                callback err
+    search: (callback) ->
+        app.replicator.db.query 'FilesAndFolder', (err, all) =>
+            results = all.rows.filter (row) =>
+                row.key[1].indexOf(@query) isnt -1
+
+            @offset = 0
+            @inPathIds = results.map (row) -> row.id
+            @loadNextPage callback
+            @trigger 'fullsync'
+
 
     # fetch use
     fetch: (callback = ->) ->

--- a/www-src/app/views/menu.coffee
+++ b/www-src/app/views/menu.coffee
@@ -49,7 +49,7 @@ module.exports = class Menu extends BaseView
 
     doSearchIfEnter: (event) => @doSearch() if event.which is 13
     doSearch: ->
-        val = $('#search-input').val()
+        val = $('#search-input').val().toLowerCase()
         return true if val.length is 0
         app.layout.closeMenu()
         app.router.navigate '#search/' + val, trigger: true

--- a/www-src/package.json
+++ b/www-src/package.json
@@ -27,7 +27,6 @@
     "moment-timezone": "0.4.1",
     "node-polyglot": "1.0.0 ",
     "pouchdb": "5.1.0",
-    "pouchdb-quick-search": "0.3.2",
     "stylus-brunch": "^1.8.1",
     "uglify-js-brunch": "> 1.0 < 1.5",
     "underscore": "1.4.4"

--- a/www-src/vendor/scripts/pouchdb.quick-search.js
+++ b/www-src/vendor/scripts/pouchdb.quick-search.js
@@ -1,1 +1,0 @@
-../../node_modules/pouchdb-quick-search/dist/pouchdb.quick-search.js


### PR DESCRIPTION
Please review #136 before this one !

Remove full text but plain words pouchdb-quick-search plugin and replace it with a systematic substring search in each folder and files names.

Speed seems decent : a few second on Motog (gen1), with 1400 files and folders.

