### PR TITLE
Fix images duplicates, move plugins to Cozy org.

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -17,7 +17,7 @@ plugins = {
     "cordova-sqlite-storage": "https://github.com/litehelpers/Cordova-sqlite-storage#r1.0.4"
     "de.appplant.cordova.plugin.local-notification": "de.appplant.cordova.plugin.local-notification@0.8.2"
 
-    "io.cozy.cordova-images-browser": "https://github.com/aenario/cordova-images-browser"
+    "io.cozy.cordova-images-browser": "https://github.com/cozy/cordova-images-browser#v1.0.2"
     "io.cozy.jsbackgroundservice": "https://github.com/cozy/cordova-jsbackgroundservice#v1.1.2"
     "io.cozy.jsbgservice-newpicture": "https://github.com/cozy/cordova-jsbgservice-newpicture#v1.0.0"
     "io.cozy.contacts": "https://github.com/cozy/cordova-plugin-contacts#c1.0.3"

--- a/Cakefile
+++ b/Cakefile
@@ -18,10 +18,10 @@ plugins = {
     "de.appplant.cordova.plugin.local-notification": "de.appplant.cordova.plugin.local-notification@0.8.2"
 
     "io.cozy.cordova-images-browser": "https://github.com/aenario/cordova-images-browser"
-    "io.cozy.jsbackgroundservice": "https://github.com/jacquarg/cordova-jsbackgroundservice#v1.1.1"
-    "io.cozy.jsbgservice-newpicture": "https://github.com/jacquarg/cordova-jsbgservice-newpicture#v1.0.0"
-    "io.cozy.contacts": "https://github.com/jacquarg/cordova-plugin-contacts#c1.0.3"
-    "io.cozy.calendarsync": "https://github.com/jacquarg/cordova-plugin-calendarsync"
+    "io.cozy.jsbackgroundservice": "https://github.com/cozy/cordova-jsbackgroundservice#v1.1.2"
+    "io.cozy.jsbgservice-newpicture": "https://github.com/cozy/cordova-jsbgservice-newpicture#v1.0.0"
+    "io.cozy.contacts": "https://github.com/cozy/cordova-plugin-contacts#c1.0.3"
+    "io.cozy.calendarsync": "https://github.com/cozy/cordova-plugin-calendarsync#v1.0.0"
 }
 
 platforms = ['android']


### PR DESCRIPTION
Fix images duplicates updating https://github.com/cozy/cordova-jsbackgroundservice to v1.1.2 .
Move specific plugins to https://github.com/cozy 

WIP : 

- @frankrousseau : https://github.com/cozy/cordova-plugin-contacts is a fork of https://github.com/apache/cordova-plugin-contacts , and has an apache licence. Is it ok ?

- DONE Thanks : @aenario I can't move this one by myself https://github.com/aenario/cordova-images-browser ; )