### PR TITLE
Update PouchDB to 5.2.0, fix timeouts on live replication.

### DIFF
--- a/www-src/app/replicator/main.coffee
+++ b/www-src/app/replicator/main.coffee
@@ -674,6 +674,7 @@ module.exports = class Replicator extends Backbone.Model
             filter: @_replicationFilter()
             since: @config.get 'checkpointed'
             live: true
+            heartbeat: false
 
         @liveReplication.on 'change', (change) =>
             realtimeBackupCoef = 1

--- a/www-src/app/replicator/replicator_config.coffee
+++ b/www-src/app/replicator/replicator_config.coffee
@@ -65,7 +65,6 @@ module.exports = class ReplicatorConfig extends Backbone.Model
     createRemotePouchInstance: ->
         new PouchDB
             name: "#{@getCozyUrl()}/replication"
-            ajax: timeout: 55 * 1000 # Before the cozy's one.
 
     appVersion: ->
         APP_VERSION

--- a/www-src/package.json
+++ b/www-src/package.json
@@ -27,7 +27,7 @@
     "moment": "2.10.6",
     "moment-timezone": "0.4.1",
     "node-polyglot": "1.0.0 ",
-    "pouchdb": "5.1.0",
+    "pouchdb": "5.2.0",
     "stylus-brunch": "^1.8.1",
     "uglify-js-brunch": "> 1.0 < 1.5",
     "underscore": "1.4.4"


### PR DESCRIPTION
* Fix recurring "500 unknown PouchDB error" by deactivating heartbeat on live replication see :  https://github.com/medic/medic-webapp/issues/1503

* Remove custom timeout for all pouchDB request (as it wasn't required, and wasn't a solution for this particuliar problem).